### PR TITLE
Fix IE11 toString error

### DIFF
--- a/misc/getPlugins.js
+++ b/misc/getPlugins.js
@@ -41,5 +41,5 @@ const flatten = (arr, result = []) => {
     return result
 }
 
-const isArray = obj => toString.call(obj) === "[object Array]";
+const isArray = obj => Object.prototype.toString.call(obj) === "[object Array]";
 export default getPlugins;


### PR DESCRIPTION
toString is called as a global function.
IE11 throws TypeError: Invalid calling object.
Object.prototype.toString doesn't result in this error.