### PR TITLE
add(type): `suneditor-react` module type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,37 @@
+import * as React from 'react';
+
+declare module 'suneditor-react' {
+  export interface SunEditorReactProps {
+    onChange?: (content: string) => void;
+    onScroll?: (event: UIEvent) => void;
+    onClick?: (event: MouseEvent) => void;
+    onKeyUp?: (event: KeyboardEvent) => void;
+    onKeyDown?: (event: KeyboardEvent) => void;
+    onDrop?: (event: DragEvent) => void;
+    onPaste?: (event: ClipboardEvent, cleanData: string, maxCharCount: boolean) => void;
+    onImageUpload?: (
+      targetImgElement: HTMLImageElement,
+      index: number,
+      state: string,
+      imageInfo: object,
+      remainingFilesCount: number
+    ) => void;
+    onImageUploadError?: (errorMessage, result) => void;
+    setOptions?: object;
+    setContents: string;
+    appendContents?: string;
+    enable?: boolean;
+    showToolbar?: boolean;
+    enableToolbar?: boolean;
+    disable?: boolean;
+    hide?: boolean;
+    show?: boolean;
+    autoFocus?: boolean;
+    placeholder?: string;
+    lang?: string | object;
+    width?: number | string;
+  }
+
+  const SunEditor: React.ComponentType<SunEditorReactProps>;
+  export default SunEditor;
+}


### PR DESCRIPTION
## Added `index.d.ts` for type infer

- `interface SunEditorReactProps`
- const SunEditor = `React.ComponentType<SunEditorReactProps>`

related suneditor issue
[https://github.com/JiHong88/SunEditor/issues/197](https://github.com/JiHong88/SunEditor/issues/197)
