### PR TITLE
Added blockquote to getPlugins

### DIFF
--- a/misc/getPlugins.js
+++ b/misc/getPlugins.js
@@ -13,6 +13,8 @@ const getPlugins = ({ buttonList }) => {
     if (buttonList.indexOf("math") >= 0)
       pluginList.push(require("suneditor/src/plugins/dialog/math").default);
 
+    if (buttonList.indexOf("blockquote") >= 0)
+      pluginList.push(require("suneditor/src/plugins/command/blockquote").default);
     if (buttonList.indexOf("font") >= 0)
       pluginList.push(require("suneditor/src/plugins/submenu/font").default);
     if (buttonList.indexOf("fontColor") >= 0)


### PR DESCRIPTION
Trying to add `blockquote` to the `buttonList` results in the following error after clicking the blockquote button:

```
main.js:15311 Uncaught TypeError: Cannot read property 'action' of undefined
```