### PR TITLE
only focus element if autoFocus is on

### DIFF
--- a/SunEditor.js
+++ b/SunEditor.js
@@ -137,7 +137,7 @@ class SunEditor extends Component {
     
     if (setContents) {
       this.editor.setContents(setContents);
-      this.editor.core.focusEdge();
+      if (autoFocus === true) this.editor.core.focusEdge();
     }
     if (setDefaultStyle) this.editor.setDefaultStyle(setDefaultStyle);
     if (insertHTML) this.editor.insertHTML(insertHTML);


### PR DESCRIPTION
When using setContents with an image, the image gets focused and the editor gets scrolled into view even if I have autoFocus off because of this function call.