### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,7 @@ export interface SunEditorReactProps {
   onFocus?: (event: FocusEvent) => void;
   onBlur?: (event: FocusEvent, editorContents: string) => void;
   onLoad?: (reload: boolean) => void;
-  onDrop?: (event: DragEvent) => void;
+  onDrop?: (event: DragEvent) => boolean;
   onPaste?: (event: ClipboardEvent, cleanData: string, maxCharCount: boolean) => void;
   onImageUpload?: (
     targetImgElement: HTMLImageElement,


### PR DESCRIPTION
https://github.com/JiHong88/SunEditor/blob/master/README.md#options

This description says if onDrop returns false, it stops rest of actions including image paste and so on. So this should return boolean, but it is void. I confirmed returning boolean changes behavior.