### PR TITLE
Update SunEditor.js

### DIFF
--- a/SunEditor.js
+++ b/SunEditor.js
@@ -201,6 +201,9 @@ class SunEditor extends Component {
     if (prevProps.appendContents !== this.props.appendContents) {
       this.editor.appendContents(this.props.appendContents);
     }
+    if (prevProps.insertHTML !== this.props.insertHTML) {
+      this.editor.insertHTML(this.props.insertHTML);
+    }
     if (prevProps.enable !== this.props.enable) {
       if (this.props.enable === true) this.editor.enabled();
       else this.editor.disabled();


### PR DESCRIPTION
To modify content from outside of SunEditor, only appendContents are prepared. But this props only adds at the end of contents. insertHTML allows insert content at the cursor.