### PR TITLE
Fixed Plugin prop bug by adding a customPlugin prop

### DIFF
--- a/SunEditor.js
+++ b/SunEditor.js
@@ -13,7 +13,7 @@ class SunEditor extends Component {
     const { lang, setOptions = {}, width = "100%", height } = this.props;
 
     setOptions.lang = setOptions.lang || getLanguage(lang);
-    setOptions.plugins = setOptions.plugins || getPlugins(setOptions);
+    setOptions.plugins = getPlugins(setOptions);
     setOptions.width = setOptions.width || width;
     if (height) setOptions.height = height;
 

--- a/dist/main.js
+++ b/dist/main.js
@@ -14494,6 +14494,10 @@ const util_util = {
         const responsiveButtons = [];
         const plugins = {};
         if (_plugins) {
+            if (options.customPlugins) {
+                // Adds the missing customPlugins to the _plugins array to fix custom plugin error
+                _plugins.push(...options.customPlugins);
+            }
             const pluginsValues = _plugins.length ? _plugins : Object.keys(_plugins).map(function(name) { return _plugins[name]; });
             for (let i = 0, len = pluginsValues.length, p; i < len; i++) {
                 p = pluginsValues[i].default || pluginsValues[i];

--- a/misc/getPlugins.js
+++ b/misc/getPlugins.js
@@ -1,4 +1,4 @@
-const getPlugins = ({ buttonList }) => {
+const getPlugins = ({ buttonList, customPlugins }) => {
   if (!buttonList) return undefined;
 
   if (!isArray(buttonList))
@@ -51,7 +51,7 @@ const getPlugins = ({ buttonList }) => {
     if (buttonList.indexOf("audio") >= 0)
       pluginList.push(require("suneditor/src/plugins/dialog/audio").default);
 
-    return pluginList;
+      return [...pluginList, ...customPlugins];
   }
 };
 

--- a/types/SetOptions.ts
+++ b/types/SetOptions.ts
@@ -100,4 +100,5 @@ export default interface SetOptions {
   audioAccept?: string;
   videoAccept?: string;
   historyStackDelayTime?: number;
+  customPlugins: Array<Plugin> | Record<string, Plugin>;
 }


### PR DESCRIPTION
Adding plugins as a prop manually causes errors when using the editor. I saw the note “Note that you do not need to pass plugins explicitly from the suneditor package. suneditor-react handles it behind the scenes” but I needed to add custom plugins and there is no way to add custom plugins without using the Plugin prop.

One of the functionality that break when using the plugin prop was image resizing which throws the following error 

`vendors.js:151813 Uncaught TypeError: this.setControllerPosition is not a function`

I found that for some reason this error is caused by the setOptions.plugins condition being run in the below line.
`setOptions.plugins = setOptions.plugins || getPlugins(setOptions);`
But when the plugins are returned from the second condition (getPlugins function), everything works as expected.

The following is what I did to fix this issue

- Created a new prop for the SunEditor component called customPlugins
- Forced plugins to always run through the getPlugins function by omitting the condition that is causing the bug
- Updated the getPlugins function to add what is passed in the customPlugins prop array to the returned array
- In main.js, I pushed the custom plugins to the _plugins array if custom plugins exist

There is now no need to pass anything in the plugin prop. If anything is passed in the prop, it will still give the same errors as it currently does for image resizing. Per the getPlugins function, it will always just load the needed plugins. In addition, any custom plugins will be able to be added when adding them to the customPlugins array. 

 So there is no need to pass anything in the Plugin prop anymore. Using the prop will still cause the same error.
I updated the getPlugins function to append the customPlugins to the returned array. The custom plugins in the array should be added as per http://suneditor.com/sample/html/customPlugins.html

Note: In the main.js file, the only change I made was adding the below to line 14497 after `if (_plugins) {`

`if (options.customPlugins) {
       // Adds the missing customPlugins to the _plugins array to fix custom plugin error
       _plugins.push(...options.customPlugins);
}`