### PR TITLE
Make customPlugins type optional

### DIFF
--- a/types/SetOptions.ts
+++ b/types/SetOptions.ts
@@ -100,5 +100,5 @@ export default interface SetOptions {
   audioAccept?: string;
   videoAccept?: string;
   historyStackDelayTime?: number;
-  customPlugins: Array<Plugin> | Record<string, Plugin>;
+  customPlugins?: Array<Plugin> | Record<string, Plugin>;
 }


### PR DESCRIPTION
Disclaimer: I didn't look into the reason why this was added, I just know having it as a requirement gave me some issues. If you think should be a required prop, please update the documentation to reflect this.

My workaround now was to add customPlugins as an empty array: 
``
              <SunEditor
                autoFocus
                placeholder="English description"
                name="description"
                onChange={setEnDesc}
                setOptions={{ buttonList: [["bold", "italic", "link"]], customPlugins: [], minHeight: 100 }}
              />
``