### PR TITLE
Update SunEditor.tsx

### DIFF
--- a/src/SunEditor.tsx
+++ b/src/SunEditor.tsx
@@ -21,6 +21,7 @@ const SunEditor: FC<SunEditorReactProps> = (props) => {
     setDefaultStyle,
     onResizeEditor,
     getSunEditorInstance,
+    getTextAreaElement,
     appendContents,
     setAllPlugins = true,
     disable = false,
@@ -59,6 +60,7 @@ const SunEditor: FC<SunEditorReactProps> = (props) => {
     });
 
     if (getSunEditorInstance) getSunEditorInstance(editor.current);
+    if (getTextAreaElement) getTextAreaElement(txtArea);
 
     editor.current.onChange = (content) => {
       if (name && txtArea.current) txtArea.current.value = content;


### PR DESCRIPTION
Sometimes we want to influence the textarea of the editor (e.g. placing custom cursor)

Right now to get the textarea element the workaround is 

const [editorElement] = document.getElementsByClassName('sun-editor-editable');

Which would not work if we have multiple editors.